### PR TITLE
Fix `NA` vs `NaN` propagation differences on valgrind

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # slider (development version)
 
+* Fixed tests that failed under valgrind due to `NA` vs `NaN` peculiarities
+  (#198).
+
 * Bumped required versions of vctrs, cli, and rlang to their current CRAN
   versions.
 
@@ -55,17 +58,17 @@
 * New family of very fast specialized sliding functions:
 
   - `slide_sum()`, `slide_index_sum()`: for rolling sums
-  
+
   - `slide_mean()`, `slide_index_mean()`: for rolling averages
-  
+
   - `slide_prod()`, `slide_index_prod()`: for rolling products
-  
+
   - `slide_min()`, `slide_index_min()`: for rolling minimums
-  
+
   - `slide_max()`, `slide_index_max()`: for rolling maximums
-  
+
   - `slide_any()`, `slide_index_any()`: for rolling any
-  
+
   - `slide_all()`, `slide_index_all()`: for rolling all
 
 * The `slide_index_*()` family now allows `.before` and `.after` to be
@@ -79,7 +82,7 @@
 * The `slide_index_*()` family has undergone some internal changes to make it
   more compatible with custom vctrs classes that could be provided as the
   index (`.i`), such as the date-time classes in the clock package (#133, #130).
-  
+
 * For the `slide_index_*()` family, it is now required that `.i - .before` and
   `.i + .after` be castable to `.i` by `vctrs::vec_cast()`. Similarly, for
   the `hop_index_*()` family, `.starts` and `.stops` must both be castable to
@@ -109,7 +112,7 @@
 
 * As a followup to a change in slider 0.1.3, edge cases with size zero input
   in `hop()` have also been fixed.
-  
+
 * C code has been refactored to be less reliant on vctrs internals.
 
 # slider 0.1.3

--- a/tests/testthat/test-summary-index.R
+++ b/tests/testthat/test-summary-index.R
@@ -41,19 +41,18 @@ test_that("NA / NaN results are correct", {
   y <- c(rep(NA, 10), rep(NaN, 10), 1:4)
   i <- seq_along(x)
 
-  expect_identical(
+  # NA vs NaN results are platform dependent in `sum()` (especially on valgrind, #198),
+  # and order dependent (but probably stable) in the segment tree, so we can't actually
+  # robustly test the actual NA vs NaN results here. Instead we just use `expect_equal()`
+  # which tests the values and the fact that there is an NA-ish thing there.
+  expect_equal(
     slide_index_sum(x, i, before = 3),
     slide_index_dbl(x, i, sum, .before = 3)
   )
-  expect_identical(
+  expect_equal(
     slide_index_sum(y, i, before = 3),
     slide_index_dbl(y, i, sum, .before = 3)
   )
-  # The NA / NaN ordering is platform dependent
-  # expect_identical(
-  #   slide_index_sum(rev(y), i, before = 3),
-  #   slide_index_dbl(rev(y), i, sum, .before = 3)
-  # )
 })
 
 test_that("`na_rm = TRUE` works", {
@@ -113,19 +112,18 @@ test_that("NA / NaN results are correct", {
   y <- c(rep(NA, 10), rep(NaN, 10), 1:4)
   i <- seq_along(x)
 
-  expect_identical(
+  # NA vs NaN results are platform dependent in `prod()` (especially on valgrind, #198),
+  # and order dependent (but probably stable) in the segment tree, so we can't actually
+  # robustly test the actual NA vs NaN results here. Instead we just use `expect_equal()`
+  # which tests the values and the fact that there is an NA-ish thing there.
+  expect_equal(
     slide_index_prod(x, i, before = 3),
     slide_index_dbl(x, i, prod, .before = 3)
   )
-  expect_identical(
+  expect_equal(
     slide_index_prod(y, i, before = 3),
     slide_index_dbl(y, i, prod, .before = 3)
   )
-  # The NA / NaN ordering is platform dependent
-  # expect_identical(
-  #   slide_index_prod(rev(y), i, before = 3),
-  #   slide_index_dbl(rev(y), i, prod, .before = 3)
-  # )
 })
 
 test_that("`na_rm = TRUE` works", {
@@ -184,19 +182,18 @@ test_that("NA / NaN results are correct", {
   y <- c(rep(NA, 10), rep(NaN, 10), 1:4)
   i <- seq_along(x)
 
-  expect_identical(
+  # NA vs NaN results are platform dependent in `mean()` (especially on valgrind, #198),
+  # and order dependent (but probably stable) in the segment tree, so we can't actually
+  # robustly test the actual NA vs NaN results here. Instead we just use `expect_equal()`
+  # which tests the values and the fact that there is an NA-ish thing there.
+  expect_equal(
     slide_index_mean(x, i, before = 3),
     slide_index_dbl(x, i, mean, .before = 3)
   )
-  expect_identical(
+  expect_equal(
     slide_index_mean(y, i, before = 3),
     slide_index_dbl(y, i, mean, .before = 3)
   )
-  # The NA / NaN ordering is platform dependent
-  # expect_identical(
-  #   slide_index_mean(rev(y), i, before = 3),
-  #   slide_index_dbl(rev(y), i, mean, .before = 3)
-  # )
 })
 
 test_that("`na_rm = TRUE` works", {

--- a/tests/testthat/test-summary-slide.R
+++ b/tests/testthat/test-summary-slide.R
@@ -43,19 +43,18 @@ test_that("NA / NaN results are correct", {
   x <- c(rep(1, 10), rep(NA, 10), 1:4)
   y <- c(rep(NA, 10), rep(NaN, 10), 1:4)
 
-  expect_identical(
+  # NA vs NaN results are platform dependent in `sum()` (especially on valgrind, #198),
+  # and order dependent (but probably stable) in the segment tree, so we can't actually
+  # robustly test the actual NA vs NaN results here. Instead we just use `expect_equal()`
+  # which tests the values and the fact that there is an NA-ish thing there.
+  expect_equal(
     slide_sum(x, before = 3),
     slide_dbl(x, sum, .before = 3)
   )
-  expect_identical(
+  expect_equal(
     slide_sum(y, before = 3),
     slide_dbl(y, sum, .before = 3)
   )
-  # The NA / NaN ordering is platform dependent
-  # expect_identical(
-  #   slide_sum(rev(y), before = 3),
-  #   slide_dbl(rev(y), sum, .before = 3)
-  # )
 })
 
 test_that("`na_rm = TRUE` works", {
@@ -71,10 +70,13 @@ test_that("Inf and -Inf results are correct", {
   expect_identical(slide_sum(x, before = 1), c(1, Inf, NaN, -Inf))
 })
 
-test_that("precision matches base R (long doubles)", {
+test_that("precision matches base R (long doubles) (#147) (#198)", {
+  skip_on_cran()
   skip_if_no_long_double()
   x <- rep(1/7, 10)
-  expect_identical(sum(x), slide_sum(x, before = Inf)[[length(x)]])
+  # Use equal, not identical, because even with long doubles some
+  # platforms like Valgrind have differences out around the 17th digit
+  expect_equal(sum(x), slide_sum(x, before = Inf)[[length(x)]])
 })
 
 test_that("Inf + -Inf = NaN propagates with `na_rm = TRUE`", {
@@ -132,19 +134,18 @@ test_that("NA / NaN results are correct", {
   x <- c(rep(1, 10), rep(NA, 10), 1:4)
   y <- c(rep(NA, 10), rep(NaN, 10), 1:4)
 
-  expect_identical(
+  # NA vs NaN results are platform dependent in `prod()` (especially on valgrind, #198),
+  # and order dependent (but probably stable) in the segment tree, so we can't actually
+  # robustly test the actual NA vs NaN results here. Instead we just use `expect_equal()`
+  # which tests the values and the fact that there is an NA-ish thing there.
+  expect_equal(
     slide_prod(x, before = 3),
     slide_dbl(x, prod, .before = 3)
   )
-  expect_identical(
+  expect_equal(
     slide_prod(y, before = 3),
     slide_dbl(y, prod, .before = 3)
   )
-  # The NA / NaN ordering is platform dependent
-  # expect_identical(
-  #   slide_prod(rev(y), before = 3),
-  #   slide_dbl(rev(y), prod, .before = 3)
-  # )
 })
 
 test_that("`na_rm = TRUE` works", {
@@ -215,19 +216,18 @@ test_that("NA / NaN results are correct", {
   x <- c(rep(1, 10), rep(NA, 10), 1:4)
   y <- c(rep(NA, 10), rep(NaN, 10), 1:4)
 
-  expect_identical(
+  # NA vs NaN results are platform dependent in `mean()` (especially on valgrind, #198),
+  # and order dependent (but probably stable) in the segment tree, so we can't actually
+  # robustly test the actual NA vs NaN results here. Instead we just use `expect_equal()`
+  # which tests the values and the fact that there is an NA-ish thing there.
+  expect_equal(
     slide_mean(x, before = 3),
     slide_dbl(x, mean, .before = 3)
   )
-  expect_identical(
+  expect_equal(
     slide_mean(y, before = 3),
     slide_dbl(y, mean, .before = 3)
   )
-  # The NA / NaN ordering is platform dependent
-  # expect_identical(
-  #   slide_mean(rev(y), before = 3),
-  #   slide_dbl(rev(y), mean, .before = 3)
-  # )
 })
 
 test_that("`na_rm = TRUE` works", {
@@ -243,10 +243,13 @@ test_that("Inf and -Inf results are correct", {
   expect_identical(slide_mean(x, before = 1), c(1, Inf, NaN, -Inf))
 })
 
-test_that("precision matches base R (long doubles)", {
+test_that("precision matches base R (long doubles) (#147) (#198)", {
+  skip_on_cran()
   skip_if_no_long_double()
   x <- c(1/7, 1/7, 1/3)
-  expect_identical(mean(x), slide_mean(x, before = Inf)[[length(x)]])
+  # Use equal, not identical, because even with long doubles some
+  # platforms like Valgrind have differences out around the 17th digit
+  expect_equal(mean(x), slide_mean(x, before = Inf)[[length(x)]])
 })
 
 test_that("Inf + -Inf = NaN propagates with `na_rm = TRUE`", {


### PR DESCRIPTION
Closes #198 

Basically, if a test combined both `NA` and `NaN` in the same `sum/mean/prod` calculation then the result is essentially up in the air as to whether it will be another `NA` or `NaN`.

While I _was_ actually trying to test this difference before by using `expect_identical()`, it isn't really worth the effort since the base equivalents don't make any promises about it either.

The easiest fix is to just switch to `expect_equal()` where `NA_real_` and `NaN` are considered equivalent.