### PR TITLE
Fix `init_compact_seq()` signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # slider (development version)
 
+* Fixed the C level function signature for a vctrs callable (#224).
+
 * Removed usage of non-API `OBJECT()`.
 
 # slider 0.3.2

--- a/src/slider-vctrs-private.c
+++ b/src/slider-vctrs-private.c
@@ -6,7 +6,7 @@ SEXP (*vec_chop)(SEXP, SEXP) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*compact_seq)(R_len_t, R_len_t, bool) = NULL;
-SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool) = NULL;
+void (*init_compact_seq)(int*, R_len_t, R_len_t, bool) = NULL;
 
 void slider_initialize_vctrs_private(void) {
   // Experimental non-public vctrs functions
@@ -15,5 +15,5 @@ void slider_initialize_vctrs_private(void) {
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "exp_vec_names");
   compact_seq = (SEXP (*)(R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "exp_short_compact_seq");
-  init_compact_seq = (SEXP (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "exp_short_init_compact_seq");
+  init_compact_seq = (void (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "exp_short_init_compact_seq");
 }

--- a/src/slider-vctrs-private.h
+++ b/src/slider-vctrs-private.h
@@ -9,6 +9,6 @@ extern SEXP (*vec_chop)(SEXP, SEXP);
 extern SEXP (*vec_slice_impl)(SEXP, SEXP);
 extern SEXP (*vec_names)(SEXP);
 extern SEXP (*compact_seq)(R_len_t, R_len_t, bool);
-extern SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool);
+extern void (*init_compact_seq)(int*, R_len_t, R_len_t, bool);
 
 #endif


### PR DESCRIPTION
Goes with https://github.com/r-lib/vctrs/pull/2103, but doesn't require it